### PR TITLE
Allow individual composable screens to replace the topBar/bottomBar or add to the topBar.

### DIFF
--- a/app/src/main/java/no/usn/mob3000/App.kt
+++ b/app/src/main/java/no/usn/mob3000/App.kt
@@ -6,12 +6,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.NavigationBarItem
@@ -57,18 +56,66 @@ import no.usn.mob3000.ui.screens.chess.train.OpeningsScreen
 import no.usn.mob3000.ui.theme.NavbarBackground
 import no.usn.mob3000.ui.theme.NavbarButtonSelected
 
+/**
+ * The LocalNavController was borne out of necessity, to allow for a more dynamic UI where
+ * individual screens can define parts of the viewport. Normally, one wouldn't pass around the
+ * NavController directly, and that's why we're it's done using local composition, to avoid
+ * callback hell.
+ *
+ * As an aside, this still shouldn't be used to pass around to individual screens unless absolutely
+ * necessary. In most cases, you merely need to use "navController.navigate()".
+ *
+ * @author frigvid
+ * @created 2024-10-02
+ */
 val LocalNavController = compositionLocalOf<NavHostController> { error("No NavController found!") }
 
 /**
- * This file is the main navigation point for the application, and serves as a place
- * for everything related to navigation.
+ * The App function serves as the main navigation point for the application. This is where you
+ * define an actual route, its underlying destinations, and whatever else is necessary.
  *
- * This function serves as the primary handler for actual route navigation, but
- * the Screen enum class defines if a route exists or not.
+ * To define a route, three things are necessary.
+ * 1. You need to create a file called <something>Screen.kt. This is under ui/screens/.
+ * 2. You need to add a destination definition to the enum class [Destination].
+ * 3. You need to define a composable route definition within the NavHost.
+ *
+ * When creating a new [Composable] screen, it's important to remember to use th [Viewport] as
+ * the root of the screen. If you don't use it, you're going to have a bad time. The reason you'd
+ * want to use it, is to allow for individual screens to replace the topBars or bottomBars, or
+ * just add certain parts to the topBar without fully replacing it. Below is a very, very basic
+ * example of a given Jetpack Compose screen.
+ * ```
+ * @Composable
+ * fun CreateOpeningScreen() {
+ *     Viewport { innerPadding ->
+ *         Box(
+ *             modifier = Modifier.fillMaxSize()
+ *                                .padding(innerPadding),
+ *             contentAlignment = Alignment.Center
+ *         ) {
+ *             Text("Create opening screen. Stub.")
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * For step 2, you'll need to register the destination definition in the enum class [Destination].
+ *
+ * Finally, to define the actual navigation logic, you'll need to create a composable route
+ * definition. This consists of 2 things, at the most basic level. A parameter where you give the
+ * destination definition from [Destination], and a body, where you call for the function you made in
+ * step 1. Below is an example of this:
+ * ```
+ * composable(route = Screen.DOCUMENTATION.name) { DocumentationScreen() }
+ * ```
+ *
+ * As you can see, the parameter is "route", and it uses the the string value of the
+ * [Destination.DOCUMENTATION]. This is what decides where it goes, and if it has an icon.
+ * Within the body, you call the function for the screen you made in step 1.
  *
  * @param navController The navigation controller.
- * @see Screen
- * @see TopNavbar
+ * @see Destination
+ * @see Viewport
  * @see ScreenIcon
  * @see Icon
  * @author frigvid
@@ -81,72 +128,142 @@ fun App(
     CompositionLocalProvider(LocalNavController provides navController) {
         NavHost(
             navController = navController,
-            startDestination = Screen.HOME.name,
+            startDestination = Destination.HOME.name,
             modifier = Modifier.fillMaxSize()
         ) {
-            composable(route = Screen.DOCUMENTATION.name) { DocumentationScreen() }
-            composable(route = Screen.FAQ.name) { FAQScreen() }
-            composable(route = Screen.NEWS.name) { NewsScreen() }
-            composable(route = Screen.HOME.name) {
+            composable(route = Destination.DOCUMENTATION.name) { DocumentationScreen() }
+            composable(route = Destination.FAQ.name) { FAQScreen() }
+            composable(route = Destination.NEWS.name) { NewsScreen() }
+            composable(route = Destination.HOME.name) {
                 HomeScreen(
-                    onTrainClick = { navController.navigate(Screen.OPENINGS.name) },
-                    onPlayClick =  { navController.navigate(Screen.PLAY.name) },
-                    onHistoryClick =  { navController.navigate(Screen.HISTORY.name) }
+                    onTrainClick = { navController.navigate(Destination.OPENINGS.name) },
+                    onPlayClick =  { navController.navigate(Destination.PLAY.name) },
+                    onHistoryClick =  { navController.navigate(Destination.HISTORY.name) }
                 )
             }
-            composable(route = Screen.OPENINGS.name) { OpeningsScreen() }
-            composable(route = Screen.GROUPS.name) { GroupsScreen() }
-            composable(route = Screen.PLAY.name) { PlayScreen() }
-            composable(route = Screen.HISTORY.name) { HistoryScreen() }
-            composable(route = Screen.PROFILE.name) { ProfileScreen() }
-            composable(route = Screen.SETTINGS.name) { SettingsScreen() }
-            composable(route = Screen.AUTH_LOGIN.name) { LoginScreen() }
-            composable(route = Screen.AUTH_CREATE.name) { CreateUserScreen() }
-            composable(route = Screen.AUTH_FORGOT.name) { ForgotPasswordScreen() }
-            composable(route = Screen.AUTH_RESET.name) { ResetPasswordScreen() }
+            composable(route = Destination.OPENINGS.name) {
+                OpeningsScreen(
+                    onGroupsClick = { navController.navigate(Destination.GROUPS.name) },
+                    onCreateOpeningClick = { navController.navigate(Destination.OPENINGS_CREATE.name) }
+                )
+            }
+            composable(route = Destination.OPENINGS_CREATE.name) { CreateOpeningScreen() }
+            composable(route = Destination.GROUPS.name) {
+                GroupsScreen(
+                    onCreateGroupClick = { navController.navigate(Destination.GROUPS_CREATE.name) },
+                    onReturnToOpeningClick = { navController.navigate(Destination.OPENINGS.name) }
+                )
+            }
+            composable(route = Destination.GROUPS_CREATE.name) { CreateGroupScreen() }
+            composable(route = Destination.PLAY.name) { PlayScreen() }
+            composable(route = Destination.HISTORY.name) { HistoryScreen() }
+            composable(route = Destination.PROFILE.name) { ProfileScreen() }
+            composable(route = Destination.SETTINGS.name) { SettingsScreen() }
+            composable(route = Destination.AUTH_LOGIN.name) { LoginScreen() }
+            composable(route = Destination.AUTH_CREATE.name) { CreateUserScreen() }
+            composable(route = Destination.AUTH_FORGOT.name) { ForgotPasswordScreen() }
+            composable(route = Destination.AUTH_RESET.name) { ResetPasswordScreen() }
         }
     }
 }
 
 /**
- * This function serves as the default viewport that screens need to implement.
+ * The [Viewport] is a wrapper function for content on a given [Composable] screen. This means that
+ * every single screen needs to have its contents wrapped inside the body of this function. See
+ * the [App] function documentation for a description of *how* one uses this at the most basic
+ * level.
  *
+ * The parameter list is not required to be used. You can wrap a screen's contents within this
+ * function's body, without adding or changing any parameters. The parameters for
+ * [topBar] and [bottomBar] both have default values for the [TopNavbar] and [BottomNavbar]
+ * functions. Which means it's not necessary to override these.
+ *
+ * However, you definitely can. It shouldn't be needed though. You can add a [floatingActionButton]
+ * and however many buttons you can fit inside the [topBar] using [topBarActions]. You can also
+ * toggle whether or not the title is shown in the [topBar] by setting [showTitle] to false.
+ *
+ * Below is an example based on [OpeningsScreen], that shows a basic way to create a
+ * [FloatingActionButton] and [IconButton] for the [floatingActionButton] and [topBarActions]
+ * parameters.
+ *
+ * ```
+ * Viewport (
+ *         floatingActionButton = {
+ *             FloatingActionButton(onClick = onCreateOpeningClick) {
+ *                 Icon(Icons.Default.Add, contentDescription = "Create opening")
+ *             }
+ *         },
+ *         topBarActions = {
+ *             IconButton(onClick = onGroupsClick) {
+ *                 Icon(Icons.Default.PlayArrow, contentDescription = "Groups")
+ *             }
+ *         }
+ *     ) { innerPadding ->
+ *         /* The body. */
+ *         Box (
+ *             Modifier.padding(innerPadding)
+ *         ) {
+ *
+ *         }
+ *     }
+ * ```
+ *
+ * TODO: Investigate and fix eventual UX problems caused by navigating in circles. E.g. if you have
+ *       destination1 and destination2, and create code that allows you to go to destination1 ->
+ *       destination2 -> destination1 -> destination2, *without* using the navigate up functionality
+ *       from the navController. You'll have to go through each destination travelled to in reverse
+ *       order, even when it doesn't make sense. Currently, you're traveling like this: destination1
+ *       <- destination2 <- destination1 <- destination2 when using the navigate up button. When it
+ *       should be like this: destination0(root) <- destination1 <- destination2.
+ *
+ * @param topBar This is the top navigation bar. By default, this is [TopNavbar].
+ * @param bottomBar This is the bottom navigation bar. By default, this is [BottomNavbar].
+ * @param showTitle This is a boolean that hides or displays the title. By default this is true.
+ * @param floatingActionButton This is floating action button in the bottom right corner of the
+                               screen. It's recommended to use [FloatingActionButton] as the button
+                               type. You can define multiple buttons, but it wasn't really designed
+                               with this in mind, and may be a bit wonky if you decide to do so.
+ * @param topBarActions This is a [RowScope] and where you define the buttons in the [TopNavbar].
+                        You can define multiple buttons.
+ * @param content This is the body of the function. You shouldn't need to pass anything to this
+                  parameter, simply write whatever content is necessary within the actual body.
+                  Feel free to use this if you want to, though, but you're on your own, man.
  * @author frigvid
  * @created 2024-10-01
  */
 @Composable
 fun Viewport(
     topBar: @Composable (
-        currentScreen: Screen,
+        currentScreen: Destination,
         canNavigateBack: Boolean,
         navigateUp: () -> Unit,
         modifier: Modifier,
-        roots: List<Screen>,
-        showTitle: Boolean,
-        topBarActions: @Composable (RowScope.() -> Unit)
-    ) -> Unit = { currentScreen, canNavigateBack, navigateUp, modifier, roots, showTitle, topBarActions ->
+        roots: List<Destination>,
+        title: Boolean,
+        actions: @Composable (RowScope.() -> Unit)
+    ) -> Unit = { currentScreen, canNavigateBack, navigateUp, modifier, roots, title, actions ->
         TopNavbar(
             currentScreen = currentScreen,
             canNavigateBack = canNavigateBack,
             navigateUp = navigateUp,
             modifier = modifier,
             roots = roots,
-            showTitle = showTitle,
-            topBarActions = topBarActions
+            showTitle = title,
+            topBarActions = actions
         )
     },
     bottomBar: @Composable (
-        rootEntries: List<Screen>,
+        rootEntries: List<Destination>,
         currentDestination: NavDestination?,
         onNavigate: (String) -> Unit
     ) -> Unit = { rootEntries, currentDestination, onNavigate ->
         BottomNavbar(
-            rootEntries = rootEntries,
+            roots = rootEntries,
             currentDestination = currentDestination,
             onNavigate = onNavigate
         )
     },
-    hideTitle: Boolean = true,
+    showTitle: Boolean = true,
     floatingActionButton: @Composable () -> Unit = {},
     topBarActions: @Composable (RowScope.() -> Unit) = {},
     content: @Composable (PaddingValues) -> Unit
@@ -154,16 +271,16 @@ fun Viewport(
     val navController = LocalNavController.current
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStackEntry?.destination
-    val currentScreen = Screen.valueOf(
-        currentBackStackEntry?.destination?.route ?: Screen.HOME.name
+    val currentScreen = Destination.valueOf(
+        currentBackStackEntry?.destination?.route ?: Destination.HOME.name
     )
 
     val rootEntries = listOf(
-        Screen.DOCUMENTATION,
-        Screen.NEWS,
-        Screen.HOME,
-        Screen.PROFILE,
-        Screen.SETTINGS
+        Destination.DOCUMENTATION,
+        Destination.NEWS,
+        Destination.HOME,
+        Destination.PROFILE,
+        Destination.SETTINGS
     )
 
     Scaffold(
@@ -174,7 +291,7 @@ fun Viewport(
                 { navController.navigateUp() },
                 Modifier,
                 rootEntries,
-                hideTitle,
+                showTitle,
                 topBarActions
             )
         },
@@ -197,14 +314,26 @@ fun Viewport(
 }
 
 /**
- * This enum class defines whether a route exists or not.
+ * This enum class defines the destination of a given route, and whether or not it has an icon.
  *
- * @param title The title, usually shown in the TopAppBar.
- * @param icon The icon, primarily shown in the BottomAppBar.
+ * A destination definition, is quite simple. You need to add a title within a `values/strings.xml`
+ * file, and whichever localizations there are. And you need to define an icon, if applicable.
+ *
+ * Here is an example of a root destination, and a regular route destination.
+ * ```
+ * SOME_ROOT_DESTINATION(title = R.string.some_route_destination, icon = Icon.DrawableResourceIcon(R.drawable.navbar_some_root_destination)),
+ * SOME_DESTINATION(title = R.string.some_destination)
+ * ```
+ *
+ * The destinations chosen for the [BottomNavbar], are controlled via a list called `rootEntries`
+ * inside the [Viewport] function.
+ *
+ * @param title The title for the destination. For example, this could be used in the [TopNavbar].
+ * @param icon The icon for the destination. Primarily used in the [BottomNavbar].
  * @author frigvid
  * @created 2024-09-24
  */
-enum class Screen(@StringRes val title: Int, val icon: Icon? = null) {
+enum class Destination(@StringRes val title: Int, val icon: Icon? = null) {
     DOCUMENTATION(title = R.string.docs_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_documentation)),
     FAQ(title = R.string.faq_title),
     NEWS(title = R.string.news_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_news)),
@@ -224,31 +353,36 @@ enum class Screen(@StringRes val title: Int, val icon: Icon? = null) {
 }
 
 /**
- * This is the navigation bar wrapper at the top of the viewport. Primarily, it serves
- * the purpose of displaying the title of the page, and providing a navigation point
- * back to the root page.
+ * This is the top navigation bar, used in the [Viewport] function. It is a wrapper for the
+ * [Composable] [TopAppBar], and is used to set default values for the top navigation bar.
+ *
+ * You're free to call on this as necessary. However, keep in mind that you'd usually only
+ * use this in the capacity of [Viewport]'s `topBar` parameter. Nothing is actually stopping
+ * you from using this directly, though.
  *
  * TODO: Show button title/label when button is pressed-and-held for a length of time.
  *       Once released, it should not fire a click-event. That'd suck.
  *
- * @param currentScreen The current route.
+ * @param currentScreen The current destination the user is on.
  * @param canNavigateBack This decides if you have a way to navigate back to the root.
- *                        Note that if a Screen enums is given through <roots>, this
- *                        navigation button will always be hidden.
- * @param navigateUp NavController's function to try to find the "root" Screen.
+                          Note that if a Screen enums is given through [roots], this
+                          navigation button will always be hidden.
+ * @param navigateUp NavController's function to try to find the "root" screen before the [currentScreen].
  * @param modifier Any modifiers, as necessary.
- * @param roots This accepts a list of Screen enums, used to decide the "root" pages.
+ * @param roots This accepts a list of [Destination] enums, used to decide the "root" pages.
+ * @param showTitle Whether or not to show the title. Boolean, default is true.
+ * @param topBarActions Any buttons to add. See [Viewport] for more information.
  * @author frigvid
  * @created 2024-09-16
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopNavbar(
-    currentScreen: Screen,
+    currentScreen: Destination,
     canNavigateBack: Boolean,
     navigateUp: () -> Unit,
     modifier: Modifier = Modifier,
-    roots: List<Screen>,
+    roots: List<Destination>,
     showTitle: Boolean = true,
     topBarActions: @Composable (RowScope.() -> Unit) = {},
 ) {
@@ -276,16 +410,34 @@ fun TopNavbar(
     )
 }
 
+/**
+ * This is the bottom navigation bar, it's used in the [Viewport] by default. It is a wrapper for the
+ * [Composable] [BottomAppBar], and is used to set default values for the bottom navigation bar.
+ *
+ * In most cases, you'd never want to directly call this. You *can* use the [Viewport]'s `bottomBar`
+ * parameter to replace it, but you're probably going to have a bad time if you do. At least if you
+ * don't define some *other* way to get back to a screen that implements the default. A regular
+ * navigate up should do the trick, but I thought I might as well warn whoever wants to directly
+ * use this beforehand.
+ *
+ * @param roots These are the "root" pages. See [Viewport]'s `rootEntries`. Without these even the
+                the destinations the buttons on this bottom navigation bar leads to, will show an
+                ineffectual back button.
+ * @param currentDestination
+ * @param onNavigate
+ * @author frigvid
+ * @created 2024-10-02
+ */
 @Composable
 fun BottomNavbar(
-    rootEntries: List<Screen>,
+    roots: List<Destination>,
     currentDestination: NavDestination?,
     onNavigate: (String) -> Unit
 ) {
     BottomAppBar(
         containerColor = NavbarBackground
     ) {
-        rootEntries.forEach { screen ->
+        roots.forEach { screen ->
             NavigationBarItem(
                 icon = {
                     screen.icon?.let {

--- a/app/src/main/java/no/usn/mob3000/App.kt
+++ b/app/src/main/java/no/usn/mob3000/App.kt
@@ -2,8 +2,9 @@ package no.usn.mob3000
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -20,6 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,6 +30,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -45,11 +49,15 @@ import no.usn.mob3000.ui.screens.auth.LoginScreen
 import no.usn.mob3000.ui.screens.auth.ResetPasswordScreen
 import no.usn.mob3000.ui.screens.chess.HistoryScreen
 import no.usn.mob3000.ui.screens.chess.PlayScreen
+import no.usn.mob3000.ui.screens.chess.train.CreateGroupScreen
+import no.usn.mob3000.ui.screens.chess.train.CreateOpeningScreen
 import no.usn.mob3000.ui.screens.info.FAQScreen
 import no.usn.mob3000.ui.screens.chess.train.GroupsScreen
 import no.usn.mob3000.ui.screens.chess.train.OpeningsScreen
 import no.usn.mob3000.ui.theme.NavbarBackground
 import no.usn.mob3000.ui.theme.NavbarButtonSelected
+
+val LocalNavController = compositionLocalOf<NavHostController> { error("No NavController found!") }
 
 /**
  * This file is the main navigation point for the application, and serves as a place
@@ -70,77 +78,11 @@ import no.usn.mob3000.ui.theme.NavbarButtonSelected
 fun App(
     navController: NavHostController = rememberNavController()
 ) {
-    val backStackEntry by navController.currentBackStackEntryAsState()
-    val currentDestination = backStackEntry?.destination
-    val currentScreen = Screen.valueOf(
-        backStackEntry?.destination?.route ?: Screen.HOME.name
-    )
-
-    /* Since the navigation bar should only have some of the routes added,
-     * this is the somewhat dirty work-around. We could just make a second
-     * route enum class for base routes, and honestly, we probably should,
-     * since regular routes have no need for an icon.
-     */
-    val rootEntries = listOf(
-        Screen.DOCUMENTATION,
-        Screen.NEWS,
-        Screen.HOME,
-        Screen.PROFILE,
-        Screen.SETTINGS
-    )
-
-    Scaffold(
-        topBar = {
-            TopNavbar(
-                currentScreen = currentScreen,
-                canNavigateBack = navController.previousBackStackEntry != null,
-                navigateUp = { navController.navigateUp() },
-                roots = rootEntries
-            )
-        },
-        bottomBar = {
-            /* TODO: Extract this. */
-            BottomAppBar(
-                containerColor = NavbarBackground
-            ) {
-                rootEntries.forEach { screen ->
-                    NavigationBarItem(
-                        icon = {
-                            screen.icon?.let {
-                                ScreenIcon(
-                                    it,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                            }
-                        },
-                        label = null, // Alternatively: label = { Text(stringResource(screen.title)) },
-                        selected = currentDestination?.hierarchy?.any { it.route == screen.name } == true,
-                        onClick = {
-                            navController.navigate(screen.name) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
-                                }
-
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        },
-                        colors = NavigationBarItemDefaults.colors(
-                            selectedIconColor = Color.White,
-                            indicatorColor = NavbarButtonSelected
-                        )
-                    )
-                }
-            }
-        }
-    ) { innerPadding ->
+    CompositionLocalProvider(LocalNavController provides navController) {
         NavHost(
             navController = navController,
             startDestination = Screen.HOME.name,
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(innerPadding)
+            modifier = Modifier.fillMaxSize()
         ) {
             composable(route = Screen.DOCUMENTATION.name) { DocumentationScreen() }
             composable(route = Screen.FAQ.name) { FAQScreen() }
@@ -167,6 +109,94 @@ fun App(
 }
 
 /**
+ * This function serves as the default viewport that screens need to implement.
+ *
+ * @author frigvid
+ * @created 2024-10-01
+ */
+@Composable
+fun Viewport(
+    topBar: @Composable (
+        currentScreen: Screen,
+        canNavigateBack: Boolean,
+        navigateUp: () -> Unit,
+        modifier: Modifier,
+        roots: List<Screen>,
+        showTitle: Boolean,
+        topBarActions: @Composable (RowScope.() -> Unit)
+    ) -> Unit = { currentScreen, canNavigateBack, navigateUp, modifier, roots, showTitle, topBarActions ->
+        TopNavbar(
+            currentScreen = currentScreen,
+            canNavigateBack = canNavigateBack,
+            navigateUp = navigateUp,
+            modifier = modifier,
+            roots = roots,
+            showTitle = showTitle,
+            topBarActions = topBarActions
+        )
+    },
+    bottomBar: @Composable (
+        rootEntries: List<Screen>,
+        currentDestination: NavDestination?,
+        onNavigate: (String) -> Unit
+    ) -> Unit = { rootEntries, currentDestination, onNavigate ->
+        BottomNavbar(
+            rootEntries = rootEntries,
+            currentDestination = currentDestination,
+            onNavigate = onNavigate
+        )
+    },
+    hideTitle: Boolean = true,
+    floatingActionButton: @Composable () -> Unit = {},
+    topBarActions: @Composable (RowScope.() -> Unit) = {},
+    content: @Composable (PaddingValues) -> Unit
+) {
+    val navController = LocalNavController.current
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = currentBackStackEntry?.destination
+    val currentScreen = Screen.valueOf(
+        currentBackStackEntry?.destination?.route ?: Screen.HOME.name
+    )
+
+    val rootEntries = listOf(
+        Screen.DOCUMENTATION,
+        Screen.NEWS,
+        Screen.HOME,
+        Screen.PROFILE,
+        Screen.SETTINGS
+    )
+
+    Scaffold(
+        topBar = {
+            topBar(
+                currentScreen,
+                navController.previousBackStackEntry != null,
+                { navController.navigateUp() },
+                Modifier,
+                rootEntries,
+                hideTitle,
+                topBarActions
+            )
+        },
+        bottomBar = {
+            bottomBar(
+                rootEntries,
+                currentDestination
+            ) { route ->
+                navController.navigate(route) {
+                    popUpTo(navController.graph.findStartDestination().id) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        },
+        floatingActionButton = floatingActionButton
+    ) { innerPadding -> content(innerPadding) }
+}
+
+/**
  * This enum class defines whether a route exists or not.
  *
  * @param title The title, usually shown in the TopAppBar.
@@ -174,30 +204,33 @@ fun App(
  * @author frigvid
  * @created 2024-09-24
  */
-enum class Screen(@StringRes val title: Int, val icon: Icon?) {
+enum class Screen(@StringRes val title: Int, val icon: Icon? = null) {
     DOCUMENTATION(title = R.string.docs_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_documentation)),
-    FAQ(title = R.string.faq_title, icon = null),
+    FAQ(title = R.string.faq_title),
     NEWS(title = R.string.news_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_news)),
     HOME(title = R.string.home_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_home)),
     PROFILE(title = R.string.profile_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_profile)),
     SETTINGS(title = R.string.settings_title, icon = Icon.DrawableResourceIcon(R.drawable.navbar_settings)),
-    OPENINGS(title = R.string.openings_title, icon = null),
-    GROUPS(title = R.string.groups_title, icon = null),
-    PLAY(title = R.string.home_play_title, icon = null),
-    HISTORY(title = R.string.home_history_title, icon = null),
-    AUTH_LOGIN(title = R.string.auth_login_title, icon = null),
-    AUTH_CREATE(title = R.string.auth_createUser_title, icon = null),
-    AUTH_FORGOT(title = R.string.auth_forgotPassword_title, icon = null),
-    AUTH_RESET(title = R.string.auth_resetPassword_title, icon = null)
+    OPENINGS(title = R.string.openings_title),
+    OPENINGS_CREATE(title = R.string.openings_create_title),
+    GROUPS(title = R.string.groups_title),
+    GROUPS_CREATE(title = R.string.groups_create_title),
+    PLAY(title = R.string.home_play_title),
+    HISTORY(title = R.string.home_history_title),
+    AUTH_LOGIN(title = R.string.auth_login_title),
+    AUTH_CREATE(title = R.string.auth_createUser_title),
+    AUTH_FORGOT(title = R.string.auth_forgotPassword_title),
+    AUTH_RESET(title = R.string.auth_resetPassword_title)
 }
 
 /**
- * This is the navigation bar at the top of the viewport. Primarily, it serves
- * the purpose of displaying the title of the page, and providing a navigation
- * point back to the root page.
+ * This is the navigation bar wrapper at the top of the viewport. Primarily, it serves
+ * the purpose of displaying the title of the page, and providing a navigation point
+ * back to the root page.
  *
  * TODO: Show button title/label when button is pressed-and-held for a length of time.
  *       Once released, it should not fire a click-event. That'd suck.
+ *
  * @param currentScreen The current route.
  * @param canNavigateBack This decides if you have a way to navigate back to the root.
  *                        Note that if a Screen enums is given through <roots>, this
@@ -215,10 +248,12 @@ fun TopNavbar(
     canNavigateBack: Boolean,
     navigateUp: () -> Unit,
     modifier: Modifier = Modifier,
-    roots: List<Screen>
+    roots: List<Screen>,
+    showTitle: Boolean = true,
+    topBarActions: @Composable (RowScope.() -> Unit) = {},
 ) {
     TopAppBar(
-        title = { Text(stringResource(currentScreen.title)) },
+        title = { if (showTitle) Text(stringResource(currentScreen.title)) },
         colors = TopAppBarDefaults.mediumTopAppBarColors(
             containerColor = NavbarBackground
         ),
@@ -236,8 +271,40 @@ fun TopNavbar(
                     )
                 }
             }
-        }
+        },
+        actions = topBarActions
     )
+}
+
+@Composable
+fun BottomNavbar(
+    rootEntries: List<Screen>,
+    currentDestination: NavDestination?,
+    onNavigate: (String) -> Unit
+) {
+    BottomAppBar(
+        containerColor = NavbarBackground
+    ) {
+        rootEntries.forEach { screen ->
+            NavigationBarItem(
+                icon = {
+                    screen.icon?.let {
+                        ScreenIcon(
+                            it,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                },
+                label = null,
+                selected = currentDestination?.hierarchy?.any { it.route == screen.name } == true,
+                onClick = { onNavigate(screen.name) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = Color.White,
+                    indicatorColor = NavbarButtonSelected
+                )
+            )
+        }
+    }
 }
 
 /**

--- a/app/src/main/java/no/usn/mob3000/MainActivity.kt
+++ b/app/src/main/java/no/usn/mob3000/MainActivity.kt
@@ -13,16 +13,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            ChessbuddyTheme {
-                App()
-                /*
-                Surface(
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    App()
-                }
-                */
-            }
+            ChessbuddyTheme { App() }
         }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * @author frigvid
@@ -29,35 +30,38 @@ fun HomeScreen(
     val screenWidth = configuration.screenWidthDp.dp
     val buttonSize = (screenWidth * 0.4f).coerceAtMost(192.dp)
 
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
         ) {
-            HomePageButton(
-                text = stringResource(R.string.home_train_title),
-                icon = R.drawable.home_train,
-                color = Color(0xFF3B82F6),
-                size = buttonSize,
-                onClick = onTrainClick
-            )
-            HomePageButton(
-                text = stringResource(R.string.home_play_title),
-                icon = R.drawable.home_play,
-                color = Color(0xFF22C55E),
-                size = buttonSize,
-                onClick = onPlayClick
-            )
-            HomePageButton(
-                text = stringResource(R.string.home_history_title),
-                icon = R.drawable.home_history,
-                color = Color(0xFFEF4444),
-                size = buttonSize,
-                onClick = onHistoryClick
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                HomePageButton(
+                    text = stringResource(R.string.home_train_title),
+                    icon = R.drawable.home_train,
+                    color = Color(0xFF3B82F6),
+                    size = buttonSize,
+                    onClick = onTrainClick
+                )
+                HomePageButton(
+                    text = stringResource(R.string.home_play_title),
+                    icon = R.drawable.home_play,
+                    color = Color(0xFF22C55E),
+                    size = buttonSize,
+                    onClick = onPlayClick
+                )
+                HomePageButton(
+                    text = stringResource(R.string.home_history_title),
+                    icon = R.drawable.home_history,
+                    color = Color(0xFFEF4444),
+                    size = buttonSize,
+                    onClick = onHistoryClick
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/ProfileScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * @author frigvid
@@ -15,7 +17,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun ProfileScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.profile_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.profile_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/SettingsScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * @author frigvid
@@ -15,7 +17,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun SettingsScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.settings_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.settings_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/auth/CreateUserScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/auth/CreateUserScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.auth
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the chessboard page, where users can free-play against an AI or
@@ -21,7 +23,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun CreateUserScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.auth_createUser_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.auth_createUser_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/auth/LoginScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.auth
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the chessboard page, where users can free-play against an AI or
@@ -20,7 +22,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun LoginScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.auth_login_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.auth_login_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/auth/ResetPasswordScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/auth/ResetPasswordScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.auth
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the chessboard page, where users can free-play against an AI or
@@ -20,7 +22,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun ResetPasswordScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.auth_resetPassword_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.auth_resetPassword_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/HistoryScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/HistoryScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.chess
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the history screen, and should display the user's previous games.
@@ -20,7 +22,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun HistoryScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.play_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.play_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/PlayScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/PlayScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.chess
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the chessboard page, where users can free-play against an AI or
@@ -18,7 +20,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun PlayScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.play_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.play_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/CreateGroupScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/CreateGroupScreen.kt
@@ -1,4 +1,4 @@
-package no.usn.mob3000.ui.screens.auth
+package no.usn.mob3000.ui.screens.chess.train
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,24 +11,15 @@ import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
 import no.usn.mob3000.Viewport
 
-/**
- * This is the chessboard page, where users can free-play against an AI or
- * fellow physically near player. (Local multiplayer, in other words).
- *
- * @see LoginScreen
- * @see ResetPasswordScreen
- * @author frigvid
- * @created 2024-09-24
- */
 @Composable
-fun ForgotPasswordScreen() {
+fun CreateGroupScreen() {
     Viewport { innerPadding ->
         Box(
             modifier = Modifier.fillMaxSize()
                                .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
-            Text(stringResource(R.string.auth_forgotPassword_title))
+            Text("Create group screen. Stub.")
         }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/CreateOpeningScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/CreateOpeningScreen.kt
@@ -1,4 +1,4 @@
-package no.usn.mob3000.ui.screens.auth
+package no.usn.mob3000.ui.screens.chess.train
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,24 +11,15 @@ import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
 import no.usn.mob3000.Viewport
 
-/**
- * This is the chessboard page, where users can free-play against an AI or
- * fellow physically near player. (Local multiplayer, in other words).
- *
- * @see LoginScreen
- * @see ResetPasswordScreen
- * @author frigvid
- * @created 2024-09-24
- */
 @Composable
-fun ForgotPasswordScreen() {
+fun CreateOpeningScreen() {
     Viewport { innerPadding ->
         Box(
             modifier = Modifier.fillMaxSize()
                                .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
-            Text(stringResource(R.string.auth_forgotPassword_title))
+            Text("Create opening screen. Stub.")
         }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/GroupsScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/GroupsScreen.kt
@@ -6,8 +6,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This shows the various chess opening groups that have been created by the active user.
@@ -22,9 +37,28 @@ import no.usn.mob3000.R
  * @author frigvid
  * @created 2024-09-24
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GroupsScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.groups_title))
+fun GroupsScreen(
+    onCreateGroupClick: () -> Unit,
+    onReturnToOpeningClick: () -> Unit
+) {
+    Viewport (
+        floatingActionButton = {
+            FloatingActionButton(onClick = onCreateGroupClick) {
+                Icon(Icons.Default.Add, contentDescription = "Create Groups")
+            }
+        },
+        topBarActions = {
+            IconButton(onClick = onReturnToOpeningClick) {
+                Icon(Icons.Default.Close, contentDescription = "Return to Openings")
+            }
+        }
+    ) { innerPadding ->
+        Box (
+            Modifier.padding(innerPadding)
+        ) {
+
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/OpeningsScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/chess/train/OpeningsScreen.kt
@@ -6,8 +6,20 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This shows the various chess openings that are available by default, and that
@@ -18,9 +30,29 @@ import no.usn.mob3000.R
  * @author frigvid
  * @created 2024-09-24
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OpeningsScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.openings_title))
+fun OpeningsScreen(
+    onGroupsClick: () -> Unit,
+    onCreateOpeningClick: () -> Unit,
+    filter: List<String>? = null
+) {
+    Viewport (
+        floatingActionButton = {
+            FloatingActionButton(onClick = onCreateOpeningClick) {
+                Icon(Icons.Default.Add, contentDescription = "Create opening")
+            }
+        },
+        topBarActions = {
+            IconButton(onClick = onGroupsClick) {
+                Icon(Icons.Default.PlayArrow, contentDescription = "Groups")
+            }
+        }
+    ) { innerPadding ->
+        Box (
+            Modifier.padding(innerPadding)
+        ) {
+
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/info/DocumentationScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/info/DocumentationScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.info
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * @author frigvid
@@ -15,7 +17,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun DocumentationScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.docs_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.docs_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/info/FAQScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/info/FAQScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.info
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * This is the FAQ page, where frequently asked questions will be displayed.
@@ -17,7 +19,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun FAQScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.faq_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.faq_title))
+        }
     }
 }

--- a/app/src/main/java/no/usn/mob3000/ui/screens/info/NewsScreen.kt
+++ b/app/src/main/java/no/usn/mob3000/ui/screens/info/NewsScreen.kt
@@ -2,12 +2,14 @@ package no.usn.mob3000.ui.screens.info
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import no.usn.mob3000.R
+import no.usn.mob3000.Viewport
 
 /**
  * @author frigvid
@@ -15,7 +17,13 @@ import no.usn.mob3000.R
  */
 @Composable
 fun NewsScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(stringResource(R.string.news_title))
+    Viewport { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize()
+                               .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.news_title))
+        }
     }
 }

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -22,6 +22,8 @@
     <!-- Openings/groups page. -->
     <string name="openings_title">Åpninger</string>
     <string name="groups_title">Grupper</string>
+    <string name="openings_create_title">ÅpningLagingStub</string>
+    <string name="groups_create_title">GruppeLagingStub</string>
 
     <!-- Play now page. -->
     <string name="play_title">Spill</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
     <!-- Openings/groups page. -->
     <string name="openings_title">Openings</string>
     <string name="groups_title">Groups</string>
+    <string name="openings_create_title">OpeningsCreateStub</string>
+    <string name="groups_create_title">GroupsCreateStub</string>
 
     <!-- Play now page. -->
     <string name="play_title">Play</string>


### PR DESCRIPTION
This pull request changes how screens are implemented. Navigation remains mostly the same, but now individual composable screens can replace the top and bottom navigation bars on any particular screen, if necessary. This comes with the caveat of needing screens to be wrapped in the new `Viewport` function.

KDoc strings should be sufficient to describe the process, see the `App` function for more information pertinent to how you'd actually use this.